### PR TITLE
Update default text styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,29 +50,38 @@ def get_font(size):
     return font
 
 def wrap_text(text, font, max_width, draw):
-    """Wrap text to fit within max_width"""
-    words = text.split()
-    lines = []
-    current_line = []
-    
-    for word in words:
-        test_line = ' '.join(current_line + [word])
-        bbox = draw.textbbox((0, 0), test_line, font=font)
-        width = bbox[2] - bbox[0]
-        
-        if width <= max_width:
-            current_line.append(word)
-        else:
-            if current_line:
-                lines.append(' '.join(current_line))
-            current_line = [word]
-    
-    if current_line:
-        lines.append(' '.join(current_line))
-    
-    return lines
+    """Wrap text to fit within max_width and respect newlines"""
+    # Split the text into paragraphs based on newlines
+    paragraphs = text.split('\n')
+    all_lines = []
 
-def generate_billboard(message, font_size=50, text_color='#ffffff'):
+    for paragraph in paragraphs:
+        if not paragraph.strip():
+            # Add empty lines for blank paragraphs (consecutive newlines)
+            all_lines.append('')
+            continue
+
+        words = paragraph.split()
+        current_line = []
+
+        for word in words:
+            test_line = ' '.join(current_line + [word])
+            bbox = draw.textbbox((0, 0), test_line, font=font)
+            width = bbox[2] - bbox[0]
+
+            if width <= max_width:
+                current_line.append(word)
+            else:
+                if current_line:
+                    all_lines.append(' '.join(current_line))
+                current_line = [word]
+
+        if current_line:
+            all_lines.append(' '.join(current_line))
+
+    return all_lines
+
+def generate_billboard(message, font_size=80, text_color='#000000'):
     """Generate billboard image with custom text"""
     # Get base image
     img = get_billboard_image()

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -81,9 +81,9 @@ downloadBtn.addEventListener('click', function() {
 // Reset to defaults
 resetBtn.addEventListener('click', function() {
     messageInput.value = 'WELCOME TO OREGON';
-    fontSizeSlider.value = 50;
-    fontSizeValue.textContent = '50px';
-    textColorInput.value = '#ffffff';
+    fontSizeSlider.value = 80;
+    fontSizeValue.textContent = '80px';
+    textColorInput.value = '#000000';
     charCount.textContent = '17/200';
     billboardPreview.style.display = 'none';
     loading.style.display = 'block';

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,13 +28,13 @@
 
                 <div class="input-group">
                     <label for="fontSize">Font Size:</label>
-                    <input type="range" id="fontSize" min="20" max="80" value="50">
-                    <span id="fontSizeValue">50px</span>
+                    <input type="range" id="fontSize" min="20" max="80" value="80">
+                    <span id="fontSizeValue">80px</span>
                 </div>
 
                 <div class="input-group">
                     <label for="textColor">Text Color:</label>
-                    <input type="color" id="textColor" value="#ffffff">
+                    <input type="color" id="textColor" value="#000000">
                 </div>
 
                 <div class="button-group">


### PR DESCRIPTION
## Summary
- Update default font size from 50px to 80px
- Change default text color from white to black
- Keep previous text wrapping enhancements that respect newlines

## Test plan
- Launch the app and verify the default text is black and sized at 80px
- Test that the reset button returns to these new defaults
- Verify that text wrapping still works correctly with newlines

🤖 Generated with [Claude Code](https://claude.ai/code)